### PR TITLE
Dummy email confirmation

### DIFF
--- a/Controllers/ApiController.cs
+++ b/Controllers/ApiController.cs
@@ -2,9 +2,11 @@ using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Net;
+using System.Net.Mail;
 using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
+using EnarcLabs.Technonomicon.Daemon.MessageService;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -18,20 +20,25 @@ namespace EnarcLabs.Technonomicon.Daemon.Controllers
         private readonly IConfiguration _configuration;
         private readonly UserManager<IdentityUser> _userManager;
         private readonly SignInManager<IdentityUser> _signInManager;
+        private readonly IMessageService _messageService;
 
-        public ApiController(IConfiguration configuration, UserManager<IdentityUser> userManager, SignInManager<IdentityUser> signInManager)
+        private string CurrentUsername => User.FindFirst(ClaimTypes.Name).Value;
+
+        public ApiController(IConfiguration configuration, UserManager<IdentityUser> userManager, SignInManager<IdentityUser> signInManager, IMessageService messageService)
         {
             _configuration = configuration;
             _userManager = userManager;
             _signInManager = signInManager;
+            _messageService = messageService;
         }
 
         [AllowAnonymous]
         [HttpPost]
-        public async Task<IActionResult> Login(string username, string password)
+        public async Task<IActionResult> Token(string username, string password)
         {
-            var a = await _signInManager.PasswordSignInAsync(username, password, false, false);
-            if(a.Succeeded)
+            var usr = await _userManager.FindByNameAsync(username);
+            var signInResult = await _signInManager.PasswordSignInAsync(usr, password, false, false);
+            if (signInResult.Succeeded && usr.EmailConfirmed) //Users are required to have a confirmed email before they can get tokens.
                 return new ObjectResult(GenerateToken(username));
 
             return BadRequest();
@@ -39,16 +46,41 @@ namespace EnarcLabs.Technonomicon.Daemon.Controllers
 
         [AllowAnonymous]
         [HttpPost]
-        public async Task<IActionResult> Register(string username, string password)
+        public async Task<IActionResult> Register(string username, string email, string password)
         {
-            var usr = await _userManager.CreateAsync(new IdentityUser { Email = username, UserName = username }, password);
-            if(!usr.Succeeded)
+            var usr = new IdentityUser { Email = email, UserName =  username };
+            var result = await _userManager.CreateAsync(usr
+                , password);
+            if(!result.Succeeded)
                 return Json(new
                 {
                     success = false,
-                    errors = usr.Errors.Select(x => x.Description).ToArray()
+                    errors = result.Errors.Select(x => x.Description).ToArray()
                 });
+
+            //TODO: Handle the result of this
+            await _messageService.Send(new MailMessage
+                {
+                    To = {email},
+                    Body = $"Your verification token is: {await _userManager.GenerateEmailConfirmationTokenAsync(usr)}"
+                });
+
             return Json(new { success = true });
+        }
+
+        [AllowAnonymous]
+        [HttpPost]
+        public async Task<IActionResult> Validate(string username, string emailToken)
+        {
+            var result = await _userManager.ConfirmEmailAsync(await _userManager.FindByNameAsync(username), emailToken);
+            if (!result.Succeeded)
+                return Json(new
+                {
+                    success = false,
+                    errors = result.Errors.Select(x => x.Description).ToArray()
+                });
+
+            return Json(new {success = true});
         }
 
         [Authorize]
@@ -73,7 +105,10 @@ namespace EnarcLabs.Technonomicon.Daemon.Controllers
                 new Claim(JwtRegisteredClaimNames.Exp, new DateTimeOffset(DateTime.Now.AddDays(1)).ToUnixTimeSeconds().ToString()),
             };
 
-            var token = new JwtSecurityToken(new JwtHeader(new SigningCredentials(new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_configuration.GetValue<string>("SecretKey"))), SecurityAlgorithms.HmacSha256)), new JwtPayload(claims));
+            var token = new JwtSecurityToken(
+                new JwtHeader(new SigningCredentials(
+                    new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_configuration.GetValue<string>("SecretKey"))),
+                    SecurityAlgorithms.HmacSha256)), new JwtPayload(claims));
 
             return new JwtSecurityTokenHandler().WriteToken(token);
         }

--- a/MessageService/DebugMessageService.cs
+++ b/MessageService/DebugMessageService.cs
@@ -1,0 +1,21 @@
+﻿using System.Diagnostics;
+using System.Linq;
+using System.Net.Mail;
+using System.Threading.Tasks;
+
+namespace EnarcLabs.Technonomicon.Daemon.MessageService
+{
+    /// <summary>
+    /// Provides IMessageService by writing message attempts to the console.
+    /// </summary>
+    /// <inheritdoc cref="IMessageService"/>
+    public class DebugMessageService : IMessageService
+    {
+        public async Task<SendResults> Send(MailMessage mail)
+        {
+            Debug.WriteLine($"Sending a message to ({string.Join("; ", mail.To.Select(x => x.Address))}): \"{mail.Body}\"");
+
+            return SendResults.Success;
+        }
+    }
+}

--- a/MessageService/IMessageService.cs
+++ b/MessageService/IMessageService.cs
@@ -1,0 +1,22 @@
+﻿using System.Net.Mail;
+using System.Threading.Tasks;
+
+namespace EnarcLabs.Technonomicon.Daemon.MessageService
+{
+    public interface IMessageService
+    {
+        /// <summary>
+        /// Sends an email.
+        /// </summary>
+        /// <param name="mail">The message to send.</param>
+        /// <returns>A task for the send operation.</returns>
+        Task<SendResults> Send(MailMessage mail);
+    }
+
+    
+    public enum SendResults
+    {
+        Success = 0,
+        Error = 1,
+    }
+}

--- a/Startup.cs
+++ b/Startup.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using EnarcLabs.Technonomicon.Daemon.MessageService;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -76,6 +77,8 @@ namespace EnarcLabs.Technonomicon.Daemon
                         ClockSkew = TimeSpan.FromMinutes(5)
                     };
                 });
+
+            services.AddTransient<IMessageService, DebugMessageService>();
         }
 
         /// <summary>


### PR DESCRIPTION
Added dummy email confirmation ability
Still not sure if this is the way to go, the email confirmation tokens are really long. So should the api submit this or the user themselves? Idk.